### PR TITLE
Adding root node annotations so Spreedly.create(SpreedlyCreditCard) w…

### DIFF
--- a/src/main/java/cc/protea/spreedly/model/SpreedlyCreditCard.java
+++ b/src/main/java/cc/protea/spreedly/model/SpreedlyCreditCard.java
@@ -3,7 +3,9 @@ package cc.protea.spreedly.model;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 
+@XmlRootElement(name = "credit_card")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class SpreedlyCreditCard {
 

--- a/src/main/java/cc/protea/spreedly/model/internal/SpreedlyPaymentMethodCreateRequest.java
+++ b/src/main/java/cc/protea/spreedly/model/internal/SpreedlyPaymentMethodCreateRequest.java
@@ -3,7 +3,9 @@ package cc.protea.spreedly.model.internal;
 import javax.xml.bind.annotation.XmlElement;
 
 import cc.protea.spreedly.model.SpreedlyCreditCard;
+import javax.xml.bind.annotation.XmlRootElement;
 
+@XmlRootElement(name = "payment_method")
 public class SpreedlyPaymentMethodCreateRequest {
 
 	@XmlElement(name = "credit_card") public SpreedlyCreditCard creditCard;


### PR DESCRIPTION
…orks correctly

Sorry if this isn't how you want to accept changes. Let me know if you would like them another way or if you want me to base this off master (I based it off of 0.9.2) since I wasn't sure if 0.9.3 was being released soon. 

Basically marshaling blows up because the root node annotations are missing for a couple classes if you try to use:

public SpreedlyTransactionResponse create(final SpreedlyCreditCard creditCard)
