### PR TITLE
Exception handling

### DIFF
--- a/src/main/java/cc/protea/spreedly/Spreedly.java
+++ b/src/main/java/cc/protea/spreedly/Spreedly.java
@@ -74,7 +74,8 @@ public class Spreedly {
 	 * @param sinceToken the last token received in the previous list
 	 */
 	public List<SpreedlyGatewayAccount> listGatewayAccounts(final String sinceToken) {
-		String url = "https://core.spreedly.com/v1/gateways.xml" + sinceToken == null ? "" : ("?since_token=" + sinceToken.trim());
+		String tokenString = sinceToken == null ? "" : ("?since_token=" + sinceToken.trim());
+		String url = "https://core.spreedly.com/v1/gateways.xml" + tokenString;
 		SpreedlyGatewayAccountResponse response = util.get(url, SpreedlyGatewayAccountResponse.class);
 		return response.gateways;
 	}

--- a/src/main/java/cc/protea/spreedly/SpreedlyException.java
+++ b/src/main/java/cc/protea/spreedly/SpreedlyException.java
@@ -2,7 +2,7 @@ package cc.protea.spreedly;
 
 import cc.protea.util.http.Response;
 
-class SpreedlyException extends RuntimeException {
+public class SpreedlyException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 	public Response response = null;

--- a/src/main/java/cc/protea/spreedly/SpreedlyUtil.java
+++ b/src/main/java/cc/protea/spreedly/SpreedlyUtil.java
@@ -3,8 +3,6 @@ package cc.protea.spreedly;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.xml.bind.DatatypeConverter;
 import javax.xml.bind.JAXBContext;
@@ -12,8 +10,8 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
-import cc.protea.spreedly.model.internal.SpreedlyErrorSetting;
 import cc.protea.spreedly.model.internal.SpreedlyErrorHash;
+import cc.protea.spreedly.model.internal.SpreedlyErrorSetting;
 import cc.protea.spreedly.model.internal.SpreedlyErrors;
 import cc.protea.util.http.Request;
 import cc.protea.util.http.Response;
@@ -161,8 +159,12 @@ class SpreedlyUtil {
 		if (in instanceof SpreedlyErrorSetting) {
 			SpreedlyErrorSetting ses = (SpreedlyErrorSetting) in;
 			ses.setError(e.errorCode, e.errorMessage);
+			return in;
+		} else {
+			// update exception message to reflect gateway error
+			RuntimeException informativeException = new RuntimeException(e.errorCode + " : " + e.errorMessage, e);
+			throw new SpreedlyException(informativeException, e.errorCode, e.errorMessage);
 		}
-		return in;
 	}
 
 	private String convert(final Object object) {


### PR DESCRIPTION
Throw a runtime exception of type SpreedlyException when gateway returns an error, provide downstream code access to Spreedly error code and message.  Currently the sdk returns an empty object of the requested type.
